### PR TITLE
Fix Styled-components rendering on client side

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
+}

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "styled-components": "^5.3.0"
+  },
+  "devDependencies": {
+    "babel-plugin-styled-components": "^1.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "grommet": "^2.17.2",
     "grommet-icons": "^4.5.0",
-    "next": "10.2.0",
+    "next": "latest",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "styled-components": "^5.3.0"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,11 @@
+import { grommet, Grommet } from 'grommet';
+
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <Grommet theme={grommet}>
+      <Component {...pageProps} />
+    </Grommet>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,43 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: App => props => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,10 @@
 import Head from "next/head";
 
 import {
-  grommet,
   Anchor,
   Avatar,
   Box,
   Footer,
-  Grommet,
   Heading,
   Nav,
   Paragraph,
@@ -19,116 +17,114 @@ export default function Home() {
     "//s.gravatar.com/avatar/b7fb138d53ba0f573212ccce38a7c43b?s=80";
 
   return (
-    <Grommet theme={grommet} full>
-      <Box
-        flex
-        margin={{ horizontal: "auto" }}
-        width={{ max: "xlarge" }}
-        height={{ min: "100%" }}
-        width={{ max: "xlarge" }}
-      >
-        <Head>
-          <title>Create Next App</title>
-          <link rel="icon" href="/favicon.ico" />
-        </Head>
+    <Box
+      flex
+      margin={{ horizontal: "auto" }}
+      width={{ max: "xlarge" }}
+      height={{ min: "100%" }}
+      width={{ max: "xlarge" }}
+    >
+      <Head>
+        <title>Create Next App</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
 
-        <Box flex role="main" pad={{ vertical: "large" }}>
-          <Heading>
-            Welcome to <Anchor href="https://nextjs.org">Next.js</Anchor> and{" "}
-            <Anchor href="https://v2.grommet.io">Grommet!</Anchor>
-          </Heading>
+      <Box flex role="main" pad={{ vertical: "large" }}>
+        <Heading>
+          Welcome to <Anchor href="https://nextjs.org">Next.js</Anchor> and{" "}
+          <Anchor href="https://v2.grommet.io">Grommet!</Anchor>
+        </Heading>
 
-          <Paragraph fill>
-            This application is a boilerplate for using Next.js Framework, React
-            library and the Grommet Component Library.
-          </Paragraph>
+        <Paragraph fill>
+          This application is a boilerplate for using Next.js Framework, React
+          library and the Grommet Component Library.
+        </Paragraph>
 
-          <Paragraph fill>
-            The application and the page you are currently viewing is the
-            default page that is created after bootstrapping a Next.js with{" "}
-            <Anchor href="https://nextjs.org/docs/api-reference/create-next-app">
-              Create Next App
-            </Anchor>
-            .
-          </Paragraph>
-
-          <Paragraph fill>
-            To the default Create Next App application we added the grommet
-            dependency, and replaced the HTML tags with actual grommet
-            components, as a result you are viewing the same default page, with
-            only Grommet components.
-          </Paragraph>
-
-          <Paragraph fill>
-            Feel free to shoot the Grommet team any feedback and questions by
-            using this page footer contact info.
-          </Paragraph>
-
-          <Paragraph fill>
-            Get started by editing <code>pages/index.js</code>
-          </Paragraph>
-
-          <Box>
-            <Anchor href="https://nextjs.org/docs">
-              <Heading level={3}>Documentation &rarr;</Heading>
-            </Anchor>
-            <Paragraph>
-              Find in-depth information about Next.js features and API.
-            </Paragraph>
-
-            <Anchor href="https://nextjs.org/learn">
-              <Heading level={3}>Learn &rarr;</Heading>
-            </Anchor>
-            <p>Learn about Next.js in an interactive course with quizzes!</p>
-
-            <Anchor href="https://github.com/vercel/next.js/tree/master/examples">
-              <Heading level={3}>Examples &rarr;</Heading>
-            </Anchor>
-            <Paragraph>
-              Discover and deploy boilerplate example Next.js projects.
-            </Paragraph>
-
-            <Anchor href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app">
-              <Heading level={3}>Deploy &rarr;</Heading>
-            </Anchor>
-            <Paragraph>
-              Instantly deploy your Next.js site to a public URL with Vercel.
-            </Paragraph>
-          </Box>
-
-          <Anchor
-            href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Next.js Powered by Vercel
+        <Paragraph fill>
+          The application and the page you are currently viewing is the
+          default page that is created after bootstrapping a Next.js with{" "}
+          <Anchor href="https://nextjs.org/docs/api-reference/create-next-app">
+            Create Next App
           </Anchor>
+          .
+        </Paragraph>
+
+        <Paragraph fill>
+          To the default Create Next App application we added the grommet
+          dependency, and replaced the HTML tags with actual grommet
+          components, as a result you are viewing the same default page, with
+          only Grommet components.
+        </Paragraph>
+
+        <Paragraph fill>
+          Feel free to shoot the Grommet team any feedback and questions by
+          using this page footer contact info.
+        </Paragraph>
+
+        <Paragraph fill>
+          Get started by editing <code>pages/index.js</code>
+        </Paragraph>
+
+        <Box>
+          <Anchor href="https://nextjs.org/docs">
+            <Heading level={3}>Documentation &rarr;</Heading>
+          </Anchor>
+          <Paragraph>
+            Find in-depth information about Next.js features and API.
+          </Paragraph>
+
+          <Anchor href="https://nextjs.org/learn">
+            <Heading level={3}>Learn &rarr;</Heading>
+          </Anchor>
+          <p>Learn about Next.js in an interactive course with quizzes!</p>
+
+          <Anchor href="https://github.com/vercel/next.js/tree/master/examples">
+            <Heading level={3}>Examples &rarr;</Heading>
+          </Anchor>
+          <Paragraph>
+            Discover and deploy boilerplate example Next.js projects.
+          </Paragraph>
+
+          <Anchor href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app">
+            <Heading level={3}>Deploy &rarr;</Heading>
+          </Anchor>
+          <Paragraph>
+            Instantly deploy your Next.js site to a public URL with Vercel.
+          </Paragraph>
         </Box>
-        <Footer
-          background="light-2"
-          pad={{ vertical: "small", horizontal: "medium" }}
+
+        <Anchor
+          href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          <Anchor href="https://github.com/ShimiSun">
-            <Avatar src={gravatarLink} />
-          </Anchor>
-          <Nav direction="row" align="center">
-            <Anchor
-              a11yTitle="Reach out to the Grommet Community on Slack"
-              href="https://slack-invite.grommet.io/"
-              icon={<Slack color="plain" />}
-              target="_blank"
-              rel="noreferrer noopener"
-            />
-            <Anchor
-              a11yTitle="Github repository"
-              href="https://github.com/grommet/nextjs-boilerplate"
-              icon={<Github color="black" />}
-              target="_blank"
-              rel="noreferrer noopener"
-            />
-          </Nav>
-        </Footer>
+          Next.js Powered by Vercel
+        </Anchor>
       </Box>
-    </Grommet>
+      <Footer
+        background="light-2"
+        pad={{ vertical: "small", horizontal: "medium" }}
+      >
+        <Anchor href="https://github.com/ShimiSun">
+          <Avatar src={gravatarLink} />
+        </Anchor>
+        <Nav direction="row" align="center">
+          <Anchor
+            a11yTitle="Reach out to the Grommet Community on Slack"
+            href="https://slack-invite.grommet.io/"
+            icon={<Slack color="plain" />}
+            target="_blank"
+            rel="noreferrer noopener"
+          />
+          <Anchor
+            a11yTitle="Github repository"
+            href="https://github.com/grommet/nextjs-boilerplate"
+            icon={<Github color="black" />}
+            target="_blank"
+            rel="noreferrer noopener"
+          />
+        </Nav>
+      </Footer>
+    </Box>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,7 +303,7 @@ available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-"babel-plugin-styled-components@>= 1.12.0":
+"babel-plugin-styled-components@>= 1.12.0", babel-plugin-styled-components@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
   integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==


### PR DESCRIPTION
## 1. Styles rendering only on client-side

### Before the fix

I noticed the project styles are not being rendered on the server-side, which causes a flick on the UI each time the page is rendered.

https://user-images.githubusercontent.com/54550926/120909888-4dce9680-c650-11eb-9e49-a5ddad54b11a.mp4

### After the fix

https://user-images.githubusercontent.com/54550926/120909907-84a4ac80-c650-11eb-895c-7a59703e838b.mp4

## 2. Grommet Context on every page

I noticed the `Grommet` context is being provided on the home page (`pages/index.js`) but this is not the best option since it will only serve the home page.

The best option is to provide the context on the `_app.js` file since it will provide Grommet context to all the pages.

## 3. Next.js version

I made a small update to the next.js version to get always the last version of next.js every time a user uses the boilerplate. It will prevent that we have to manually bump the version every time a new next.js version is released.