### PR TITLE
Add a command to bootstrap the boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 For the deployment and introduction visit the application website https://practical-montalcini-0d3675.netlify.app/
 
+## How to use
+
+Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the boilerplate:
+
+```bash
+npx create-next-app --example https://github.com/grommet/nextjs-boilerplate my-project-name
+# or
+yarn create next-app --example https://github.com/grommet/nextjs-boilerplate my-project-name
+```
+
 ## Getting Started
 
 First, run the development server:


### PR DESCRIPTION
Adding a command to make it easier for users to bootstrap this boilerplate so they won't have to manually download this project then download the dependencies and change its name.