### PR TITLE
Lastest version of React

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "grommet": "^2.17.2",
     "grommet-icons": "^4.5.0",
     "next": "latest",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "latest",
+    "react-dom": "latest",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest version of NextJS relies on the latest version of React in most cases.